### PR TITLE
#14 - Rely on `MetaService` to preview title, description and image metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This changelog is incomplete. Pull requests with entries before 1.10.0
 are welcome.
 
+## [1.11.0] - 2023-07-20
+### Changed
+- Rely on `MetaService` to preview title, description and image metadata
+
 ## [1.10.4] - 2023-06-29
 ### Added 
 - `og:url` and `og:type`

--- a/src/Controller/PreviewModalController.php
+++ b/src/Controller/PreviewModalController.php
@@ -9,6 +9,7 @@ use Drupal\file\FileInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\wmmedia\Plugin\Field\FieldType\MediaImageExtras;
 use Drupal\wmmeta\Entity\EntityMetaInterface;
+use Drupal\wmmeta\Service\MetaService;
 use Drupal\wmmeta\Service\UrlHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -17,11 +18,14 @@ class PreviewModalController implements ContainerInjectionInterface
 {
     /** @var UrlHelper */
     protected $urlHelper;
+    /** @var MetaService */
+    protected $metaService;
 
     public static function create(ContainerInterface $container)
     {
         $instance = new static();
         $instance->urlHelper = $container->get('wmmeta.url_helper');
+        $instance->metaService = $container->get('wmmeta.meta');
 
         return $instance;
     }
@@ -115,8 +119,10 @@ class PreviewModalController implements ContainerInjectionInterface
             throw new NotFoundHttpException('Meta does not have an image field');
         }
 
-        $settings['metadata']['title'] = $entity->label();
-        $settings['metadata']['desc'] = $meta->get('field_meta_description')->value;
+        $metaData = $this->metaService->getEntityMetaData($entity);
+
+        $settings['metadata']['title'] = $metaData['title'] ?? $entity->label();
+        $settings['metadata']['desc'] = $metaData['description'] ?? $meta->get('field_meta_description')->value;
 
         $url = $entity->toUrl()->setAbsolute()->toString();
         $urlParts = parse_url($url);
@@ -126,7 +132,7 @@ class PreviewModalController implements ContainerInjectionInterface
             'base_domain' => sprintf('%s://%s', $urlParts['scheme'], $urlParts['host']),
         ];
 
-        $image = $meta->get('field_meta_image')->first();
+        $image = $metaData['image'] ?? $meta->get('field_meta_image')->first();
 
         if ($image instanceof MediaImageExtras && $image->getFile() instanceof FileInterface) {
             $settings['facebook']['featured_image'] = $this->getImageUrl($image->getFile(), 'og');

--- a/src/Service/MetaService.php
+++ b/src/Service/MetaService.php
@@ -77,7 +77,7 @@ class MetaService
         $this->entity = $entity;
     }
 
-    public function getEntityMetaData(EntityMetaInterface $entity): array
+    protected function getEntityMetaData(EntityMetaInterface $entity): array
     {
         return array_filter($entity->toMetaOGArray());
     }

--- a/src/Service/MetaService.php
+++ b/src/Service/MetaService.php
@@ -77,7 +77,7 @@ class MetaService
         $this->entity = $entity;
     }
 
-    protected function getEntityMetaData(EntityMetaInterface $entity): array
+    public function getEntityMetaData(EntityMetaInterface $entity): array
     {
         return array_filter($entity->toMetaOGArray());
     }


### PR DESCRIPTION
## Description

Having `Drupal\wmcustom\Service\MetaService` extending `Drupal\wmmeta\Service\MetaService\MetaService` allows overriding `title`, `description`, and other meta information.

But, that meta information is ignored by `PreviewModalController` which keeps using the default information from the meta entity.

We should instead rely on that `MetaService` and retrieve the meta information from there.

### Documentation

n/a

## Related Issues

Follows https://github.com/wieni/www.watwat.be/issues/2.